### PR TITLE
Pre Release 0.2.4

### DIFF
--- a/launcher_core/_types.py
+++ b/launcher_core/_types.py
@@ -6,16 +6,17 @@ This module contains all Types for minecraft-launcher-lib.
 If you are not interested in static typing just ignore it.
 For more information about TypedDict see `PEP 589 <https://peps.python.org/pep-0589/>`_.
 """
-from typing import Literal, TypedDict, Callable, Union
+from typing import Literal, TypedDict, Callable, Union, NewType
 import datetime
 from uuid import UUID
 from dataclasses import dataclass
 
+MinecraftUUID = NewType("MinecraftUUID", UUID)
 
 class MinecraftOptions(TypedDict, total=False):
     '''The options for the Minecraft Launcher'''
     username: str
-    uuid: UUID
+    uuid: MinecraftUUID
     token: str
     executablePath: str
     defaultExecutablePath: str
@@ -23,7 +24,7 @@ class MinecraftOptions(TypedDict, total=False):
     launcherName: str
     launcherVersion: str
     gameDirectory: str
-    demo: bool
+    demo: bool = False
     customResolution: bool
     resolutionWidth: Union[int, str, None]
     resolutionHeight: Union[int, str, None]
@@ -220,12 +221,12 @@ class JavaPatchNotes(TypedDict):
     entries: list[_JavaPatchNoteEntry]
 
 
-@dataclass
+@dataclass(frozen=True)
 class Credential:
     '''The credential of the player'''
     access_token: str = None
     username: str = None
-    uuid: UUID = None
+    uuid: MinecraftUUID = None
     refresh_token: str = None
 
 
@@ -268,7 +269,7 @@ class MinecraftProfileResponse(TypedDict, total=False):
     capes: list[MinecraftProfileCape]  # 新版
 
 
-@dataclass
+@dataclass(frozen=True)
 class AzureApplication:
     '''The Azure Application ID and Secret'''
     # The client ID of the Azure Application

--- a/launcher_core/_types.py
+++ b/launcher_core/_types.py
@@ -6,7 +6,7 @@ This module contains all Types for minecraft-launcher-lib.
 If you are not interested in static typing just ignore it.
 For more information about TypedDict see `PEP 589 <https://peps.python.org/pep-0589/>`_.
 """
-from typing import Literal, TypedDict, Callable
+from typing import Literal, TypedDict, Callable, Union
 import datetime
 from uuid import UUID
 from dataclasses import dataclass
@@ -25,8 +25,8 @@ class MinecraftOptions(TypedDict, total=False):
     gameDirectory: str
     demo: bool
     customResolution: bool
-    resolutionWidth: str
-    resolutionHeight: str
+    resolutionWidth: Union[int, str, None]
+    resolutionHeight: Union[int, str, None]
     server: str
     port: str
     nativesDirectory: str
@@ -103,9 +103,9 @@ class JavaInformation(TypedDict):
     path: str
     name: str
     version: str
-    java_path: str
-    javaw_path: str | None
-    is_64bit: bool
+    javaPath: str
+    javawPath: str | None
+    is64Bit: bool
     openjdk: bool
 
 

--- a/launcher_core/command.py
+++ b/launcher_core/command.py
@@ -16,7 +16,8 @@ from ._internal_types.shared_types import ClientJson, ClientJsonArgumentRule
 from .runtime import get_executable_path
 from .exceptions import VersionNotFound
 from .utils import get_library_version
-from ._types import MinecraftOptions, Credential
+from ._types import MinecraftOptions
+from ._types import Credential as AuthCredential
 from .natives import get_natives
 
 __all__ = ["get_minecraft_command"]
@@ -83,8 +84,8 @@ async def replace_arguments(
         "${user_type}": "msa",
         "${version_type}": version_data["type"],
         "${user_properties}": "{}",
-        "${resolution_width}": options.get("resolutionWidth", "854"),
-        "${resolution_height}": options.get("resolutionHeight", "480"),
+        "${resolution_width}": options.get("resolutionWidth", 854),
+        "${resolution_height}": options.get("resolutionHeight", 480),
         "${game_assets}": os.path.join(path, "assets", "virtual", "legacy"),
         "${auth_session}": options.get("token", "{token}"),
         "${library_directory}": os.path.join(path, "libraries"),
@@ -176,7 +177,7 @@ async def get_minecraft_command(
     version: str,
     minecraft_directory: str | os.PathLike,
     options: MinecraftOptions,
-    Credential: Credential | None = None,
+    Credential: AuthCredential | None = None,
 ) -> list[str]:
     """
     Returns the command for running minecraft as list. The given command can be executed with subprocess. Use :func:`~launcher_core.utils.get_minecraft_directory` to get the default Minecraft directory.
@@ -252,11 +253,11 @@ async def get_minecraft_command(
     if "executablePath" in options:
         command.append(options["executablePath"])
     elif "javaVersion" in data:
-        java_path = await get_executable_path(data["javaVersion"]["component"], path)
-        if java_path is None:
+        javaPath = await get_executable_path(data["javaVersion"]["component"], path)
+        if javaPath is None:
             command.append("java")
         else:
-            command.append(java_path)
+            command.append(javaPath)
     else:
         command.append(options.get("defaultExecutablePath", "java"))
 

--- a/launcher_core/java_utils.py
+++ b/launcher_core/java_utils.py
@@ -21,11 +21,11 @@ async def get_java_information(path: str | os.PathLike) -> JavaInformation:
 
     .. code:: python
 
-        java_path = "<path>"
-        information = await launcher_corejava_utils.get_java_information(java_path)
+        javaPath = "<path>"
+        information = await launcher_core.java_utils.get_java_information(javaPath)
         print("Name: " + information["name"])
         print("Version: " + information["version"])
-        print("Java path: " + information["java_path"])
+        print("Java path: " + information["javaPath"])
 
     :param path: The Path to the Installation. It must be the Directory. 
     If your Java executable is e.g. /usr/lib/jvm/java-19-openjdk-amd64/bin/java 
@@ -61,19 +61,19 @@ async def get_java_information(path: str | os.PathLike) -> JavaInformation:
     information["path"] = str(path)
     information["name"] = os.path.basename(path)
     information["version"] = re.search(r'(?<=version ")[\d|\.|_]+(?=")', lines[0]).group()
-    information["is_64bit"] = "64-Bit" in lines[2]
+    information["is64Bit"] = "64-Bit" in lines[2]
     information["openjdk"] = lines[0].startswith("openjdk")
 
     if platform.system() == "Windows":
-        information["java_path"] = os.path.join(
+        information["javaPath"] = os.path.join(
             os.path.abspath(path), "bin", "java.exe"
         )
-        information["javaw_path"] = os.path.join(
+        information["javawPath"] = os.path.join(
             os.path.abspath(path), "bin", "javaw.exe"
         )
     else:
-        information["java_path"] = os.path.join(os.path.abspath(path), "bin", "java")
-        information["javaw_path"] = None
+        information["javaPath"] = os.path.join(os.path.abspath(path), "bin", "java")
+        information["javawPath"] = None
 
     return information
 
@@ -110,7 +110,7 @@ async def find_system_java_versions(
 
     .. code:: python
 
-        for version in await launcher_corejava_utils.find_system_java_versions():
+        for version in await launcher_core.java_utils.find_system_java_versions():
             print(version)
 
     :param additional_directories: 
@@ -155,7 +155,7 @@ async def find_system_java_versions_information(
             print("Path: " + version_information["path"])
             print("Name: " + version_information["name"])
             print("Version: " + version_information["version"])
-            print("Java path: " + version_information["java_path"])
+            print("Java path: " + version_information["javaPath"])
             print()
 
     :param additional_directories: A List of additional Directories to search for Java in custom locations

--- a/launcher_core/microsoft_account.py
+++ b/launcher_core/microsoft_account.py
@@ -22,7 +22,8 @@ from .exceptions import (
     XErrNotFound,
     DeviceCodeExpiredError,
 )
-from ._types import AzureApplication, Credential
+from ._types import AzureApplication
+from ._types import Credential as AuthCredential
 from .logging_utils import logger
 
 __AUTH_URL__ = "https://login.live.com/oauth20_authorize.srf"
@@ -310,7 +311,7 @@ class device_code_login:
 
 async def refresh_minecraft_token(
     azure_app: AzureApplication = AzureApplication(),
-    Credential: Credential = None,
+    Credential: AuthCredential = None,
 ) -> AuthorizationTokenResponse:
     """
     Refresh the Minecraft token using the refresh token.

--- a/launcher_core/mojang.py
+++ b/launcher_core/mojang.py
@@ -11,7 +11,8 @@ import json
 from typing import Optional
 import aiohttp
 import aiofiles
-from ._types import SkinData, Credential, MinecraftProfileResponse
+from ._types import SkinData, MinecraftProfileResponse
+from ._types import Credential as AuthCredential
 from .exceptions import AccountNotOwnMinecraft, NeedAccountInfo
 
 
@@ -21,7 +22,7 @@ class Skin:
     用于处理 Minecraft 皮肤的类。
     提供获取皮肤 URL、上传皮肤、重置皮肤等功能。
     '''
-    def __init__(self, Credential: Credential):
+    def __init__(self, Credential: AuthCredential):
         self.Credential = Credential
 
     async def get_skin_and_cape(self) -> Optional[SkinData]:

--- a/launcher_core/runtime.py
+++ b/launcher_core/runtime.py
@@ -267,7 +267,7 @@ async def get_executable_path(
     :param jvm_version: The Name of the JVM version
     :param minecraft_directory: The path to your Minecraft directory
     """
-    java_path = os.path.join(
+    javaPath = os.path.join(
         minecraft_directory,
         "runtime",
         jvm_version,
@@ -276,16 +276,16 @@ async def get_executable_path(
         "bin",
         "java",
     )
-    if os.path.isfile(java_path):
-        return java_path
-    elif os.path.isfile(java_path + ".exe"):
-        return java_path + ".exe"
-    java_path = java_path.replace(
+    if os.path.isfile(javaPath):
+        return javaPath
+    elif os.path.isfile(javaPath + ".exe"):
+        return javaPath + ".exe"
+    javaPath = javaPath.replace(
         os.path.join("bin", "java"),
         os.path.join("jre.bundle", "Contents", "Home", "bin", "java"),
     )
-    if os.path.isfile(java_path):
-        return java_path
+    if os.path.isfile(javaPath):
+        return javaPath
     else:
         return None
 

--- a/launcher_core/vanilla_launcher.py
+++ b/launcher_core/vanilla_launcher.py
@@ -197,8 +197,8 @@ async def vanilla_launcher_profile_to_minecraft_options(
 
     if (custom_resolution := vanilla_profile.get("customResolution")) is not None:
         options["customResolution"] = True
-        options["resolutionWidth"] = str(custom_resolution["width"])
-        options["resolutionHeight"] = str(custom_resolution["height"])
+        options["resolutionWidth"] = custom_resolution["width"]
+        options["resolutionHeight"] = custom_resolution["height"]
 
     return options
 


### PR DESCRIPTION
This pull request introduces several updates to improve type safety, standardize naming conventions, and enhance error handling in the `launcher_core` module. Key changes include the introduction of a new type alias for UUIDs, updates to the `MinecraftOptions` and related types, and consistent naming for Java-related attributes. Additionally, error handling has been improved in the `parse_single_rule` function, and imports have been reorganized for clarity.

### Type Safety and Data Structures:
* Introduced `MinecraftUUID` as a `NewType` to improve type safety for UUIDs in `launcher_core/_types.py`. Updated `uuid` fields in `MinecraftOptions` and `Credential` to use `MinecraftUUID`. [[1]](diffhunk://#diff-a81b24440457c75a5bad91bde0b998c8e9c418a396b280f3b771a9c37ba0477aL9-R30) [[2]](diffhunk://#diff-a81b24440457c75a5bad91bde0b998c8e9c418a396b280f3b771a9c37ba0477aL223-R229)
* Updated `MinecraftOptions` to allow `resolutionWidth` and `resolutionHeight` as `Union[int, str, None]` and provided default values for `demo`.
* Marked `Credential` and `AzureApplication` dataclasses as immutable by adding the `frozen=True` parameter. [[1]](diffhunk://#diff-a81b24440457c75a5bad91bde0b998c8e9c418a396b280f3b771a9c37ba0477aL223-R229) [[2]](diffhunk://#diff-a81b24440457c75a5bad91bde0b998c8e9c418a396b280f3b771a9c37ba0477aL271-R272)

### Naming Standardization:
* Standardized Java-related attribute names in `JavaInformation` and related functions by using camelCase (e.g., `javaPath`, `is64Bit`) for consistency. [[1]](diffhunk://#diff-a81b24440457c75a5bad91bde0b998c8e9c418a396b280f3b771a9c37ba0477aL106-R109) [[2]](diffhunk://#diff-9bcb671ca7a250727d775b37569b91e69731906181ae7bc73d0c9974ef2bf36bL24-R28) [[3]](diffhunk://#diff-9bcb671ca7a250727d775b37569b91e69731906181ae7bc73d0c9974ef2bf36bL64-R76)

### Error Handling:
* Added validation for invalid `action` values in the `parse_single_rule` function to raise a `ValueError` if an unexpected action is encountered.

### Code Simplification:
* Updated `async def replace_arguments` and `vanilla_launcher_profile_to_minecraft_options` to directly use integer values for resolution width and height instead of converting them to strings. [[1]](diffhunk://#diff-67c788297291ef9b2a5987cbbe9ffdc5927d181b718888d535fd754942ff31c1L86-R88) [[2]](diffhunk://#diff-45d2f448893df88103f7314eeb2109bbaece0b465f3a3ab99d129588403c8412L200-R201)

### Import Reorganization:
* Reorganized imports across multiple files for better readability and to avoid circular dependencies. This includes aliasing `Credential` as `AuthCredential` where necessary. [[1]](diffhunk://#diff-916d35c79aec3d8682a2b3b34f4fe1bb0def462ccc712bfb7bbe204b186a5765L5-L13) [[2]](diffhunk://#diff-67c788297291ef9b2a5987cbbe9ffdc5927d181b718888d535fd754942ff31c1L19-R20) [[3]](diffhunk://#diff-ec097445006709e1ee57a22117b67aa3da6b19ee87589ceed9e021afb95aa9b8L25-R26) [[4]](diffhunk://#diff-f6b842c48dfa9093a16a13c06e373dee385440f64c68faba2ab451c95aeabc0bL14-R15)