### PR TITLE
refactor: remove unused imports and clean up test files

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -6,7 +6,6 @@ Run all tests with various configurations and generate coverage reports
 
 import pytest
 import sys
-import os
 from pathlib import Path
 
 # Add the project root to Python path

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,13 +1,11 @@
 import pytest
 import sys
 import os
-from unittest.mock import Mock, patch, MagicMock
-from pathlib import Path
 
 # Add the project root to Python path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from launcher_core import utils, exceptions, _types
+from launcher_core import exceptions, _types
 from launcher_core.utils import sync
 
 

--- a/tests/test_install_command.py
+++ b/tests/test_install_command.py
@@ -1,7 +1,7 @@
 import pytest
 import sys
 import os
-from unittest.mock import Mock, patch, MagicMock, AsyncMock
+from unittest.mock import Mock, patch, AsyncMock
 import tempfile
 import shutil
 from pathlib import Path
@@ -17,10 +17,10 @@ class AsyncContextManagerMock:
     """Helper class to mock async context managers"""
     def __init__(self, return_value):
         self.return_value = return_value
-    
+
     async def __aenter__(self):
         return self.return_value
-    
+
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         pass
 
@@ -110,7 +110,7 @@ class TestInstall:
                             ]
                         }
                     )
-                    
+
                     # Set up proper async context manager mock
                     mock_get = Mock(return_value=AsyncContextManagerMock(mock_manifest_response))
                     mock_session_instance = Mock()
@@ -119,7 +119,7 @@ class TestInstall:
 
                     # This demonstrates the async context manager fix
                     await install.install_minecraft_version("1.20.4", temp_minecraft_dir)
-                    
+
                     # Verify the mock was called correctly
                     mock_do_install.assert_called_once()
 
@@ -128,11 +128,12 @@ class TestCommand:
     """Test cases for command module"""
 
 @ pytest.fixture
-def  temp_minecraft_dir（）：
+@pytest.fixture
+def temp_minecraft_dir():
     """建立暫存的 Minecraft 目錄用於測試"""
-    temp_dir  =  tempfile.mkdtemp ( )
-    產量 temp_dir
-    關閉. rmtree（temp_dir）
+    temp_dir = tempfile.mkdtemp()
+    yield temp_dir
+    shutil.rmtree(temp_dir)
 
     async def test_get_minecraft_command(self, temp_minecraft_dir):
         """Test generating Minecraft launch command"""

--- a/tests/test_microsoft_account.py
+++ b/tests/test_microsoft_account.py
@@ -1,8 +1,7 @@
 import pytest
 import sys
 import os
-from unittest.mock import Mock, patch, MagicMock
-import asyncio
+from unittest.mock import Mock, patch
 
 # Add the project root to Python path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))

--- a/tests/test_mod_loaders.py
+++ b/tests/test_mod_loaders.py
@@ -1,10 +1,7 @@
 import pytest
 import sys
 import os
-from unittest.mock import Mock, patch, MagicMock, AsyncMock
-import tempfile
-import shutil
-from pathlib import Path
+from unittest.mock import Mock, patch, AsyncMock
 
 # Add the project root to Python path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))

--- a/tests/test_mojang_config.py
+++ b/tests/test_mojang_config.py
@@ -1,7 +1,7 @@
 import pytest
 import sys
 import os
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
 import tempfile
 import shutil
 from pathlib import Path

--- a/tests/test_utils_runtime.py
+++ b/tests/test_utils_runtime.py
@@ -1,7 +1,7 @@
 import pytest
 import sys
 import os
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
 import tempfile
 import shutil
 from pathlib import Path


### PR DESCRIPTION
This pull request focuses on cleaning up and standardizing the test files by removing unused imports, fixing a minor formatting issue, and improving a test fixture. Below is a summary of the most important changes grouped by theme:

### Import Cleanup and Standardization:
* Removed unused imports such as `MagicMock`, `Path`, `tempfile`, and `shutil` from various test files, including `tests/test_core.py`, `tests/test_install_command.py`, `tests/test_microsoft_account.py`, `tests/test_mod_loaders.py`, `tests/test_mojang_config.py`, and `tests/test_utils_runtime.py`. This helps streamline the code and reduce unnecessary dependencies. [[1]](diffhunk://#diff-938de46e643ab091cff6a7c23e4e752e8907e2266f47889d988923352f7a1058L4-R8) [[2]](diffhunk://#diff-ab734f8a1cee2afe1785b18778d6f15979503da482461a5b3aff7e3a983728f2L4-R4) [[3]](diffhunk://#diff-008f00750e0202857be9fe62aed6060360f375fc1696a7b29278327fb13e7ffbL4-R4) [[4]](diffhunk://#diff-cf0531f6715fff8d6f477ca10da7b42ae346f9c23489c74751835866e35ba33aL4-R4) [[5]](diffhunk://#diff-c2e8b046f463b9dcb481a6206be64820eade9776c7fe13625cadecf786992b1aL4-R4) [[6]](diffhunk://#diff-1a2fe531ee6e74c83aeee54cac97803101d7ff1de64e15fa81b6724345cdf933L4-R4)

### Test Fixture Improvement:
* Fixed a formatting issue and corrected the implementation of the `temp_minecraft_dir` fixture in `tests/test_install_command.py`. The fixture now uses proper syntax and ensures cleanup of the temporary directory with `shutil.rmtree`.

### Minor Adjustments:
* Removed an unused `os` import from `tests/run_tests.py` to further clean up the code.